### PR TITLE
Update `UnbindFiltersFromProjections` helper function

### DIFF
--- a/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
+++ b/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
@@ -3,19 +3,19 @@ package norm
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
 func (c *CustomFuncs) HasConstantGroupingCols(
 	input memo.RelExpr, groupingPrivate *memo.GroupingPrivate,
 ) bool {
-	_, _, _, ok := c.extractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
+	_, _, _, ok := c.ExtractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
 	return ok
 }
 
-func (c *CustomFuncs) extractConstantGroupingColsAndBuildDummy(
+func (c *CustomFuncs) ExtractConstantGroupingColsAndBuildDummy(
 	input memo.RelExpr, groupingPrivate *memo.GroupingPrivate,
 ) (constantCols opt.ColSet, constantValues memo.ScalarListExpr, dummyCols opt.ColList, ok bool) {
 	project, ok := input.(*memo.ProjectExpr)
@@ -51,21 +51,21 @@ func (c *CustomFuncs) extractConstantGroupingColsAndBuildDummy(
 func (c *CustomFuncs) GetConstantGroupingCols(
 	input memo.RelExpr, groupingPrivate *memo.GroupingPrivate,
 ) opt.ColSet {
-	constantCols, _, _, _ := c.extractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
+	constantCols, _, _, _ := c.ExtractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
 	return constantCols
 }
 
 func (c *CustomFuncs) GetConstantValues(
 	input memo.RelExpr, groupingPrivate *memo.GroupingPrivate,
 ) memo.ScalarListExpr {
-	_, constantValues, _, _ := c.extractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
+	_, constantValues, _, _ := c.ExtractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
 	return constantValues
 }
 
 func (c *CustomFuncs) GetDummyCols(
 	input memo.RelExpr, groupingPrivate *memo.GroupingPrivate,
 ) opt.ColList {
-	_, _, dummyCols, _ := c.extractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
+	_, _, dummyCols, _ := c.ExtractConstantGroupingColsAndBuildDummy(input, groupingPrivate)
 	return dummyCols
 }
 
@@ -150,7 +150,7 @@ func (c *CustomFuncs) ConstructAggregateProjectConstantToDummyJoin(
 ) memo.RelExpr {
 	project := input.(*memo.ProjectExpr)
 
-	constantCols, constantValues, dummyCols, ok := c.extractConstantGroupingColsAndBuildDummy(project, groupingPrivate)
+	constantCols, constantValues, dummyCols, ok := c.ExtractConstantGroupingColsAndBuildDummy(project, groupingPrivate)
 	if !ok {
 		panic(errors.AssertionFailedf("should have matched"))
 	}

--- a/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
+++ b/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
@@ -809,47 +809,6 @@ func (c *CustomFuncs) BindFiltersToProjections(
 }
 
 
-func deriveGroupByRejectNullCols(
-	mem *memo.Memo, in memo.RelExpr, disabledRules intsets.Fast,
-) opt.ColSet {
-	input := in.Child(0).(memo.RelExpr)
-	aggs := *in.Child(1).(*memo.AggregationsExpr)
-
-	var rejectNullCols opt.ColSet
-	var savedInColID opt.ColumnID
-	for i := range aggs {
-		agg := memo.ExtractAggFunc(aggs[i].Agg)
-		aggOp := agg.Op()
-
-		if aggOp == opt.ConstAggOp {
-			continue
-		}
-
-		if !opt.AggregateIgnoresNulls(aggOp) || !opt.AggregateIsNullOnEmpty(aggOp) {
-			return opt.ColSet{}
-		}
-
-		var inColID opt.ColumnID
-		if v, ok := agg.Child(0).(*memo.VariableExpr); ok {
-			inColID = v.Col
-		} else {
-			return opt.ColSet{}
-		}
-
-		if savedInColID != 0 && savedInColID != inColID {
-			return opt.ColSet{}
-		}
-		savedInColID = inColID
-
-		if !DeriveRejectNullCols(mem, input, disabledRules).Contains(inColID) {
-			return opt.ColSet{}
-		}
-
-		rejectNullCols.Add(aggs[i].Col)
-	}
-	return rejectNullCols
-}
-
 func (c *CustomFuncs) AllFiltersCanMapOnSetOp(filters memo.FiltersExpr) bool {
 	for i := range filters {
 		if !c.CanMapOnSetOp(&filters[i]) {
@@ -987,4 +946,3 @@ func (c *CustomFuncs) MakeSetPrivate(
 		OutCols:   outColsCopy,
 	}
 }
-

--- a/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
+++ b/src/main/java/org/qed/Backends/Cockroach/helperfuncs.go
@@ -771,7 +771,7 @@ func (c *CustomFuncs) IsSemiJoin(input memo.RelExpr) bool {
 	}
 }
 
-func (c *CustomFuncs) UnbindFiltersFromProjections(
+func (c *CustomFuncs) RebuildFiltersWithRemappedCols(
 	projections memo.ProjectionsExpr, filters memo.FiltersExpr,
 ) memo.FiltersExpr {
 	var colMap opt.ColMap


### PR DESCRIPTION
Noticed that the `UnbindFiltersFromProjections` helper function has already been defined in [project_functions.go](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/opt/norm/project_funcs.go#L977-L988). However it hasn't been used in any of the generated rules and isn't used in the generator either, so maybe it was an intentional redefinition? (Currently the build errors for me because of it.)